### PR TITLE
Remote pytest and sphinc from install requires

### DIFF
--- a/README.org
+++ b/README.org
@@ -11,3 +11,8 @@ It also, hopefully soon, will serve as an ActivityStreams validator.
 More things will go here in the future, in the meanwhile maybe see
 [[file:./activipy.org][activipy.org]] in this directory for braindumps and tasks.
 
+## Development
+
+Install all the dependencies as follows:
+
+    pip install -e .[dev]

--- a/setup.py
+++ b/setup.py
@@ -27,14 +27,13 @@ setup(
     include_package_data=True,
     install_requires=[
         "PyLD",
-        "pytest",
-        "sphinx",
-        ],
-    # @@: Can we reproduce this in Guix?
-    entry_points="""\
-        [console_scripts]
-        activipy_tester = activipy.testcli:main
-        """,
+    ],
+    extras_require={
+        "dev": [
+            "pytest",
+            "sphinx",
+        ]
+    },
     license="Apache v2",
     author="Christopher Allan Webber",
     author_email="cwebber@dustycloud.org",


### PR DESCRIPTION
Including these install a lot of dependencies which are not needed for actually using the library. I would like to propose putting them in extras instead so they can easily be installed in a development environment using:

    pip install -e .[dev]

This is the difference:

    $ pip install -e .
    Successfully installed PyLD-0.7.2 activipy

VS

    $ pip install -e .[dev]
    Successfully installed Jinja2-2.9.6 MarkupSafe-1.0 Pygments-2.2.0 activipy alabaster-0.7.10 babel-2.4.0 docutils-0.13.1 imagesize-0.7.1 py-1.4.33 pytest-3.0.7 pytz-2017.2 requests-2.14.2 snowballstemmer-1.2.1 sphinx-1.5.5

In a production system all those extra packages are not very nice :)

This does however create a problem with the console scripts. Is there a reason the test client needs to be installed via a package?