### PR TITLE
Replace deprecated pkg_resources with importlib

### DIFF
--- a/activipy/core.py
+++ b/activipy/core.py
@@ -17,9 +17,13 @@
 ##   See the License for the specific language governing permissions and
 ##   limitations under the License.
 
-from pkg_resources import resource_filename
 import copy
 import json
+try:
+    from importlib.resources import files
+except ImportError:
+    # Fallback for Python < 3.9
+    from importlib_resources import files
 
 from pyld import jsonld
 
@@ -129,9 +133,8 @@ class ASVocab(object):
 
 
 # TODO: Add this one by default
-AS2_CONTEXT_FILE = resource_filename(
-    'activipy', 'activitystreams2-context.jsonld')
-AS2_CONTEXT = json.loads(open(AS2_CONTEXT_FILE, 'r').read())
+AS2_CONTEXT_FILE = files('activipy').joinpath('activitystreams2-context.jsonld')
+AS2_CONTEXT = json.loads(AS2_CONTEXT_FILE.read_text())
 AS2_CONTEXT_URI = (
     "http://www.w3.org/TR/activitystreams-core/activitystreams2-context.jsonld")
 AS2_DEFAULT_URL_MAP = {


### PR DESCRIPTION
### Problem

`pkg_resources` has been removed from Setuptools 72.0.0+ (see [setuptools#3085](https://github.com/pypa/setuptools/issues/3085)), causing import errors in environments with newer Setuptools versions.

---

### Solution

This PR replaces the deprecated `pkg_resources.resource_filename` with the modern standard library alternative `importlib.resources.files`, which is the recommended approach for accessing package resources.

---

### Changes

- Removed `pkg_resources` import
- Added `importlib.resources.files` with fallback to `importlib_resources` for `Python < 3.9`
- Updated resource file access to use the new API:
  - `files('activipy').joinpath('activitystreams2-context.jsonld')`
  - `.read_text()` instead of `open().read()`

---

### Compatibility

- Python 3.9+: Uses built-in `importlib.resources`
- Python < 3.9: Falls back to `importlib_resources` package (needs to be added as a dependency)

---

### Testing

Existing tests pass with the new implementation.

The change is a drop-in replacement with no functional differences.

---

### Note

Projects using this library with Python < 3.9 will need to install `importlib_resources` as a dependency.